### PR TITLE
fix: worker threads not being recreated on exit

### DIFF
--- a/src/Pool.js
+++ b/src/Pool.js
@@ -3,6 +3,26 @@ var WorkerHandler = require("./WorkerHandler");
 var environment = require("./environment");
 var DebugPortAllocator = require("./debug-port-allocator");
 var DEBUG_PORT_ALLOCATOR = new DebugPortAllocator();
+
+/**
+ * @typedef {"auto" | "thread" | "thread" | "web"} WorkerType
+ * @typedef {Object} WorkerPoolOptions
+ * @property {string[]} [forkArgs]
+ * @property {import('child_process').ForkOptions} [forkOpts]
+ * @property {import('worker_threads').WorkerOptions} [workerThreadOpts]
+ * @property {number} [debugPortStart]
+ * @property {WorkerType} [nodeWorker] alias to workerType
+ * @property {boolean} [roundrobin]
+ * @property {WorkerType} [workerType]
+ * @property {number} [maxQueueSize]
+ * @property {number} [concurrency]
+ * @property {number} [gradualScaling]
+ * @property {number} [maxExec] the number of distinct executions allowed
+ * @property {Function} [onCreateWorker]
+ * @property {Function} [onTerminateWorker]
+ * @property {number} [maxWorkers]
+ * @property {number | "max"} [minWorkers]
+ */
 /**
  * A pool to manage workers
  * @param {String} [script]   Optional worker script
@@ -33,6 +53,7 @@ function Pool(script, options) {
   this.concurrency = options.concurrency;
   this.gradualScaling = options.gradualScaling || 0;
   this.canCreateWorker = true;
+  this.maxExec = options.maxExec || 0;
 
   this.onCreateWorker = options.onCreateWorker || (() => null);
   this.onTerminateWorker = options.onTerminateWorker || (() => null);
@@ -258,7 +279,7 @@ Pool.prototype._getWorker = function (affinity) {
   if (!chosenWorker) {
     for (var i = 0; i < workers.length; i++) {
       var worker = workers[i];
-      if (worker.busy() === false) {
+      if (worker.available()) {
         chosenWorker = worker;
         break;
       }
@@ -322,8 +343,9 @@ Pool.prototype.wstats = function () {
     if (statObj.lastTime < worker.lastTime) {
       statObj.lastTime = worker.lastTime;
     }
-    statObj.totalUtil +=
-      worker.worker.performance.eventLoopUtilization().utilization;
+    statObj.totalUtil += worker.worker.performance
+      ? worker.worker.performance.eventLoopUtilization().utilization
+      : 0;
   }
 
   statObj.avgUtil = statObj.totalUtil / workers.length;
@@ -419,6 +441,16 @@ Pool.prototype.terminate = function (force, timeout) {
 };
 
 /**
+ * Retrieve the number of available workers.
+ * @return {number}
+ */
+Pool.prototype.getNumberAvailableWorkers = function () {
+  return this.workers.filter(function (worker) {
+    return worker.available();
+  }).length;
+};
+
+/**
  * Retrieve statistics on tasks and workers.
  * @return {{totalWorkers: number, busyWorkers: number, idleWorkers: number, pendingTasks: number, activeTasks: number}} Returns an object with statistics
  */
@@ -431,6 +463,7 @@ Pool.prototype.stats = function () {
   return {
     totalWorkers: totalWorkers,
     busyWorkers: busyWorkers,
+    availableWorkers: this.getNumberAvailableWorkers(),
     idleWorkers: totalWorkers - busyWorkers,
 
     pendingTasks: this.tasks.length,
@@ -464,7 +497,7 @@ Pool.prototype._createWorkerHandler = function () {
       script: this.script,
     }) || {};
 
-  return new WorkerHandler(overridenParams.script || this.script, {
+  const worker = new WorkerHandler(overridenParams.script || this.script, {
     forkArgs: overridenParams.forkArgs || this.forkArgs,
     forkOpts: overridenParams.forkOpts || this.forkOpts,
     workerThreadOpts: overridenParams.workerThreadOpts || this.workerThreadOpts,
@@ -473,7 +506,13 @@ Pool.prototype._createWorkerHandler = function () {
     ),
     workerType: this.workerType,
     concurrency: this.concurrency,
+    maxExec: overridenParams.maxExec || this.maxExec,
+    onWorkerExit: () => {
+      this._removeWorker(worker);
+    },
   });
+
+  return worker;
 };
 
 /**


### PR DESCRIPTION
## What's the issue this PR is solving?

Workers that exit are not replaced immidiately, add maxExec to options, add getNumberAvailableWorkers to pool, add typing

## What are you changing?

- add missing WorkerPoolOptions type
- add maxExec to options which only allows `maxExec` number of executions (if falsey will have no effect)
- in `_getWorker` remove terminated workers and only pick from "available" workers
- add `onWorkerExit` to WorkerHandler options which is called only once and when the worker exits and/or cannot accept new requests
- add `responseCount` to WorkerHandler to count number or responses and when they exceed `maxExec` will signal exit
- add `available()` to WorkerHandler which checks `requestCount` and `maxExec` along with busy/terminated/terminating/ready

### Notes

- This PR is needed by https://github.com/Gearlay/TokenStalker/pull/596
- since WorkerHandler was not linted I added a lint commit first then my work afterwards to make it easier to review and see what changed (check second commit)

### Types of changes

- New feature (non-breaking change which adds functionality)

## Screenshots / Screencasts

NA