### PR TITLE
feat: add markNotReadyAfterExec option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,14 @@ exports.workerEmit = function workerEmit(payload) {
 };
 
 /**
+ * tells the parent pool that this worker is ready.
+ */
+exports.workerReady = function workerReady() {
+  var worker = require("./worker");
+  worker.ready();
+};
+
+/**
  * Create a promise.
  * @type {Promise} promise
  */

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-var environment = require('./environment');
+var environment = require("./environment");
 
 /**
  * Create a new worker pool
@@ -7,7 +7,7 @@ var environment = require('./environment');
  * @returns {Pool} pool
  */
 exports.pool = function pool(script, options) {
-  var Pool = require('./Pool');
+  var Pool = require("./Pool");
 
   return new Pool(script, options);
 };
@@ -17,16 +17,16 @@ exports.pool = function pool(script, options) {
  * @param {Object} [methods]
  */
 exports.worker = function worker(methods) {
-  var worker = require('./worker');
+  var worker = require("./worker");
   worker.add(methods);
 };
 
 /**
  * Sends an event to the parent worker pool.
- * @param {any} payload 
+ * @param {any} payload
  */
 exports.workerEmit = function workerEmit(payload) {
-  var worker = require('./worker');
+  var worker = require("./worker");
   worker.emit(payload);
 };
 
@@ -34,7 +34,7 @@ exports.workerEmit = function workerEmit(payload) {
  * Create a promise.
  * @type {Promise} promise
  */
-exports.Promise = require('./Promise');
+exports.Promise = require("./Promise");
 
 exports.platform = environment.platform;
 exports.isMainThread = environment.isMainThread;

--- a/src/worker.js
+++ b/src/worker.js
@@ -5,74 +5,82 @@
 
 // source of inspiration: https://github.com/sindresorhus/require-fool-webpack
 var requireFoolWebpack = eval(
-    'typeof require !== \'undefined\'' +
-    ' ? require' +
-    ' : function (module) { throw new Error(\'Module " + module + " not found.\') }'
+  "typeof require !== 'undefined'" +
+    " ? require" +
+    " : function (module) { throw new Error('Module \" + module + \" not found.') }"
 );
 
 /**
  * Special message sent by parent which causes the worker to terminate itself.
  * Not a "message object"; this string is the entire message.
  */
-var TERMINATE_METHOD_ID = '__workerpool-terminate__';
+var TERMINATE_METHOD_ID = "__workerpool-terminate__";
 
 // var nodeOSPlatform = require('./environment').nodeOSPlatform;
 
 // create a worker API for sending and receiving messages which works both on
 // node.js and in the browser
 var worker = {
-  exit: function() {}
+  exit: function () {},
 };
-if (typeof self !== 'undefined' && typeof postMessage === 'function' && typeof addEventListener === 'function') {
+if (
+  typeof self !== "undefined" &&
+  typeof postMessage === "function" &&
+  typeof addEventListener === "function"
+) {
   // worker in the browser
   worker.on = function (event, callback) {
     addEventListener(event, function (message) {
       callback(message.data);
-    })
+    });
   };
   worker.send = function (message) {
     postMessage(message);
   };
-}
-else if (typeof process !== 'undefined') {
+} else if (typeof process !== "undefined") {
   // node.js
 
   var WorkerThreads;
   try {
-    WorkerThreads = requireFoolWebpack('worker_threads');
-  } catch(error) {
-    if (typeof error === 'object' && error !== null && error.code === 'MODULE_NOT_FOUND') {
+    WorkerThreads = requireFoolWebpack("worker_threads");
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      error.code === "MODULE_NOT_FOUND"
+    ) {
       // no worker_threads, fallback to sub-process based workers
     } else {
       throw error;
     }
   }
 
-  if (WorkerThreads &&
+  if (
+    WorkerThreads &&
     /* if there is a parentPort, we are in a WorkerThread */
-    WorkerThreads.parentPort !== null) {
-    var parentPort  = WorkerThreads.parentPort;
+    WorkerThreads.parentPort !== null
+  ) {
+    var parentPort = WorkerThreads.parentPort;
     worker.send = parentPort.postMessage.bind(parentPort);
     worker.on = parentPort.on.bind(parentPort);
   } else {
     worker.on = process.on.bind(process);
     worker.send = process.send.bind(process);
     // register disconnect handler only for subprocess worker to exit when parent is killed unexpectedly
-    worker.on('disconnect', function () {
+    worker.on("disconnect", function () {
       process.exit(1);
     });
     worker.exit = process.exit.bind(process);
   }
-}
-else {
-  throw new Error('Script must be executed as a worker');
+} else {
+  throw new Error("Script must be executed as a worker");
 }
 
 function convertError(error) {
-  return Object.getOwnPropertyNames(error).reduce(function(product, name) {
+  return Object.getOwnPropertyNames(error).reduce(function (product, name) {
     return Object.defineProperty(product, name, {
-	value: error[name],
-	enumerable: true
+      value: error[name],
+      enumerable: true,
     });
   }, {});
 }
@@ -84,7 +92,11 @@ function convertError(error) {
  *                    having functions `then` and `catch`.
  */
 function isPromise(value) {
-  return value && (typeof value.then === 'function') && (typeof value.catch === 'function');
+  return (
+    value &&
+    typeof value.then === "function" &&
+    typeof value.catch === "function"
+  );
 }
 
 // functions available externally
@@ -97,7 +109,7 @@ worker.methods = {};
  * @returns {*}
  */
 worker.methods.run = function run(fn, args) {
-  var f = new Function('return (' + fn + ').apply(null, arguments);');
+  var f = new Function("return (" + fn + ").apply(null, arguments);");
   return f.apply(f, args);
 };
 
@@ -111,7 +123,7 @@ worker.methods.methods = function methods() {
 
 var currentRequestId = null;
 
-worker.on('message', function (request) {
+worker.on("message", function (request) {
   if (request === TERMINATE_METHOD_ID) {
     return worker.exit(0);
   }
@@ -120,50 +132,47 @@ worker.on('message', function (request) {
 
     if (method) {
       currentRequestId = request.id;
-      
+
       // execute the function
       var result = method.apply(method, request.params);
 
       if (isPromise(result)) {
         // promise returned, resolve this and then return
         result
-            .then(function (result) {
-              worker.send({
-                id: request.id,
-                result: result,
-                error: null
-              });
-              currentRequestId = null;
-            })
-            .catch(function (err) {
-              worker.send({
-                id: request.id,
-                result: null,
-                error: convertError(err)
-              });
-              currentRequestId = null;
+          .then(function (result) {
+            worker.send({
+              id: request.id,
+              result: result,
+              error: null,
             });
-      }
-      else {
+            currentRequestId = null;
+          })
+          .catch(function (err) {
+            worker.send({
+              id: request.id,
+              result: null,
+              error: convertError(err),
+            });
+            currentRequestId = null;
+          });
+      } else {
         // immediate result
         worker.send({
           id: request.id,
           result: result,
-          error: null
+          error: null,
         });
 
         currentRequestId = null;
       }
-    }
-    else {
+    } else {
       throw new Error('Unknown method "' + request.method + '"');
     }
-  }
-  catch (err) {
+  } catch (err) {
     worker.send({
       id: request.id,
       result: null,
-      error: convertError(err)
+      error: convertError(err),
     });
   }
 });
@@ -173,7 +182,6 @@ worker.on('message', function (request) {
  * @param {Object} methods
  */
 worker.register = function (methods) {
-
   if (methods) {
     for (var name in methods) {
       if (methods.hasOwnProperty(name)) {
@@ -182,8 +190,7 @@ worker.register = function (methods) {
     }
   }
 
-  worker.send('ready');
-
+  worker.send("ready");
 };
 
 worker.emit = function (payload) {
@@ -191,12 +198,12 @@ worker.emit = function (payload) {
     worker.send({
       id: currentRequestId,
       isEvent: true,
-      payload
+      payload,
     });
   }
 };
 
-if (typeof exports !== 'undefined') {
+if (typeof exports !== "undefined") {
   exports.add = worker.register;
   exports.emit = worker.emit;
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -77,6 +77,9 @@ if (
 }
 
 function convertError(error) {
+  if (typeof error === "string") {
+    return error;
+  }
   return Object.getOwnPropertyNames(error).reduce(function (product, name) {
     return Object.defineProperty(product, name, {
       value: error[name],
@@ -203,7 +206,12 @@ worker.emit = function (payload) {
   }
 };
 
+worker.ready = function () {
+  worker.send("ready");
+};
+
 if (typeof exports !== "undefined") {
   exports.add = worker.register;
   exports.emit = worker.emit;
+  exports.ready = worker.ready;
 }


### PR DESCRIPTION
## What's the issue this PR is solving?

Adding option to mark worker not ready once it finishes execution

## What are you changing?

- add `markNotReadyAfterExec` to pool options (defaults to false). It is forwarded to worker constructor
- add `initReadyTimeoutDuration` to pool options (defaults to `readyTimeoutDuration`). It is forwarded to worker constructor. It is the initial/first ready timeout duration after which the worker is terminated
- add `readyTimeoutDuration` to pool options (defaults to 0). It is forwarded to worker constructor. It is the ready timeout duration for none init/first ready timeout
- upon exec complete in worker check `markNotReadyAfterExec` and set ready to false if it is true
- add `workerReady` function to index.js to be used by worker to signal readiness
- 

### Types of changes

- New feature (non-breaking change which adds functionality)

## Notes:

I kept linting in first commit. Look at second commit for better change visibility

## Screenshots / Screencasts

NA