### PR TITLE
feat(worker): signal not ready

### DIFF
--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -307,11 +307,16 @@ function WorkerHandler(script, _options) {
     if (me.terminated) {
       return;
     }
-    if (typeof response === "string" && response === "ready") {
+    if (response === "ready") {
       me.clearReadyTimeout();
       me.worker.ready = true;
       me.onWorkerReady();
       dispatchQueuedRequests();
+    } else if (response === "notready") {
+      dispatchQueuedRequests();
+      me.clearReadyTimeout();
+      me.setReadyTimeout(me.readyTimeoutDuration);
+      me.worker.ready = false;
     } else {
       // find the task from the processing queue, and run the tasks callback
       var id = response.id;

--- a/src/worker.js
+++ b/src/worker.js
@@ -206,8 +206,13 @@ worker.emit = function (payload) {
   }
 };
 
-worker.ready = function () {
-  worker.send("ready");
+worker.ready = function (isReady) {
+  isReady = isReady == null ? true : isReady;
+  if (isReady) {
+    worker.send("ready");
+  } else {
+    worker.send("notready");
+  }
 };
 
 if (typeof exports !== "undefined") {


### PR DESCRIPTION
## What's the issue this PR is solving?

the worker can now signal not ready

## What are you changing?

- worker.ready now accepts a bool arg that defaults to true and will signal ready or notready depending on this boolean
- the WorkerHandler listens to notready event and marks the worker as not ready

### Types of changes

- New feature (non-breaking change which adds functionality)

## Screenshots / Screencasts

NA
