### PR TITLE
revert: revert respect availability

### DIFF
--- a/src/Pool.js
+++ b/src/Pool.js
@@ -505,6 +505,7 @@ Pool.prototype._createWorkerHandler = function () {
       script: this.script,
     }) || {};
 
+  console.info("Creating new worker for script", this.script);
   const worker = new WorkerHandler(overridenParams.script || this.script, {
     forkArgs: overridenParams.forkArgs || this.forkArgs,
     forkOpts: overridenParams.forkOpts || this.forkOpts,

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -370,6 +370,12 @@ function WorkerHandler(script, _options) {
 
   // reject all running tasks on worker error
   function onError(error) {
+    console.warn(
+      "Worker exited for script",
+      me.script,
+      "(This might be expected)\n",
+      error
+    );
     me.terminated = true;
 
     for (var id in me.processing) {

--- a/src/WorkerHandler.js
+++ b/src/WorkerHandler.js
@@ -505,8 +505,8 @@ WorkerHandler.prototype.busy = function () {
 WorkerHandler.prototype.available = function () {
   return (
     this.worker &&
-    !this.worker.terminated &&
-    !this.worker.terminating &&
+    !this.terminated &&
+    !this.terminating &&
     this.worker.ready &&
     (!this.maxExec || this.requestCount < this.maxExec) &&
     !this.busy()


### PR DESCRIPTION
## What's the issue this PR is solving?

The change in the getWorker seems to have degraded performance. added more logs to worker exit and create

## What are you changing?

- remove changes to getWorker
- fix issue with `available()` function
- add logs on worker error
- add log on worker create

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Screenshots / Screencasts

NA